### PR TITLE
fix: Remove URL encoding from Pure.md API calls

### DIFF
--- a/src/services/pure-md.ts
+++ b/src/services/pure-md.ts
@@ -28,7 +28,7 @@ export class PureMdClient {
 
   async fetchContent(url: string): Promise<string> {
     try {
-      const response = await this.axios.get(`/${encodeURIComponent(url)}`);
+      const response = await this.axios.get(`/${url}`);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -48,7 +48,7 @@ export class PureMdClient {
     }
 
     try {
-      const response = await this.axios.post(`/${encodeURIComponent(url)}`, {
+      const response = await this.axios.post(`/${url}`, {
         prompt: options.prompt || 'Extract the main content and metadata',
         model: options.model || 'meta/llama-3.1-8b',
       });

--- a/tests/unit/services/pure-md.test.ts
+++ b/tests/unit/services/pure-md.test.ts
@@ -65,7 +65,7 @@ describe('PureMdClient', () => {
 
       const result = await client.fetchContent('https://example.com');
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/https%3A%2F%2Fexample.com');
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/https://example.com');
       expect(result).toBe(mockContent);
     });
 
@@ -118,7 +118,7 @@ describe('PureMdClient', () => {
       const result = await client.extractData('https://example.com', {});
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        '/https%3A%2F%2Fexample.com',
+        '/https://example.com',
         {
           prompt: 'Extract the main content and metadata',
           model: 'meta/llama-3.1-8b',
@@ -137,7 +137,7 @@ describe('PureMdClient', () => {
       });
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        '/https%3A%2F%2Fexample.com',
+        '/https://example.com',
         {
           prompt: 'Custom prompt',
           model: 'custom/model',


### PR DESCRIPTION
## Summary

This PR fixes an issue where URLs were being encoded before being sent to the Pure.md API, which was causing API calls to fail.

## Problem

The Pure.md API expects raw URLs to be passed directly in the path, but we were using `encodeURIComponent()` which was converting URLs like:
- `https://example.com` → `https%3A%2F%2Fexample.com`

This was causing the API to return 400 Bad Request errors.

## Solution

- Removed `encodeURIComponent()` from both `fetchContent()` and `extractData()` methods
- Updated tests to expect raw URLs instead of encoded ones
- All tests now passing

## Changes

1. **src/services/pure-md.ts**
   - Line 31: Changed from `/${encodeURIComponent(url)}` to `/${url}`
   - Line 51: Changed from `/${encodeURIComponent(url)}` to `/${url}`

2. **tests/unit/services/pure-md.test.ts**
   - Updated test expectations to match raw URLs

## Testing

- ✅ All unit tests passing
- ✅ All integration tests passing
- [ ] Manual testing with actual Pure.md API key

## Breaking Changes

None - This is a bug fix that makes the API calls work correctly.