### PR TITLE
chore: Bump version to 0.1.0-beta.9

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -44673,7 +44673,7 @@ var coerce = {
 };
 var NEVER = INVALID;
 // src/version.ts
-var VERSION = "0.1.0-beta.8";
+var VERSION = "0.1.0-beta.9";
 var USER_AGENT = `Archivist/${VERSION}`;
 var DEFAULT_USER_AGENT = USER_AGENT;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarwp/archivist",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "description": "A Bun-based tool for archiving web content as LLM context using Pure.md API",
   "keywords": ["web-archiver", "content-extraction", "pure-md", "llm", "web-crawler", "bun"],
   "homepage": "https://github.com/stellarwp/archivist#readme",

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,11 +3,11 @@
  * Update this file when releasing new versions
  */
 
-export const VERSION = '0.1.0-beta.8';
+export const VERSION = '0.1.0-beta.9';
 export const VERSION_MAJOR = 0;
 export const VERSION_MINOR = 1;
 export const VERSION_PATCH = 0;
-export const VERSION_PRERELEASE = 'beta.8';
+export const VERSION_PRERELEASE = 'beta.9';
 
 export const USER_AGENT = `Archivist/${VERSION}`;
 export const DEFAULT_USER_AGENT = USER_AGENT;


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0-beta.8 to 0.1.0-beta.9
- Includes recent fix for bundling issue with config imports

## Changes
- Updated version in `package.json`
- Updated version constants in `src/version.ts`
- Rebuilt CLI with new version number

## Context
This release includes the fix for the bundling issue where archivist would hang when installed as a dependency (PR #19).