### PR TITLE
Fix: Save collected-links.json in archive output directories

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,6 @@ program
   .option('--dry-run', 'Collect and display all URLs without crawling')
   .option('--no-confirm', 'Skip confirmation prompt and proceed directly')
   .option('--show-all-urls', 'Show all URLs instead of just the first 20')
-  .option('--save-links <path>', 'Save collected links to specified JSON file', 'collected-links.json')
   .option('--clean', 'Clean output directories before crawling')
   .action(async (options) => {
     try {
@@ -103,11 +102,12 @@ program
       
       await webCrawler.collectAllUrls();
       
-      // Save collected links to file
-      if (options.saveLinks) {
-        stateService.saveCollectedLinksFile(options.saveLinks);
-        logger.info(`\nCollected links saved to: ${options.saveLinks}`);
+      // Save collected links to each archive's output directory
+      for (const archive of config.archives) {
+        const collectedLinksPath = path.join(archive.output.directory, 'collected-links.json');
+        stateService.saveArchiveCollectedLinks(archive.name, collectedLinksPath);
       }
+      logger.info(`\nCollected links saved to each archive's output directory`);
       
       const totalUrls = stateService.getTotalUrlCount();
       const paginationStats = stateService.getPaginationStats();

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -296,6 +296,43 @@ export class StateService {
     writeFileSync(outputPath, JSON.stringify(linksData, null, 2));
   }
   
+  // Save collected links for a specific archive
+  saveArchiveCollectedLinks(archiveName: string, outputPath: string): void {
+    const archiveUrls = this.state.collectedUrls.filter(item => item.archiveName === archiveName);
+    
+    if (archiveUrls.length === 0) {
+      return;
+    }
+    
+    const totalUrls = archiveUrls.reduce((sum, item) => sum + item.urls.length, 0);
+    const totalPaginationPages = archiveUrls.reduce((sum, item) => sum + (item.paginationPages || 0), 0);
+    
+    const linksData = {
+      timestamp: new Date().toISOString(),
+      archiveName: archiveName,
+      summary: {
+        totalSources: archiveUrls.length,
+        totalUrls: totalUrls,
+        paginationPages: totalPaginationPages,
+      },
+      sources: archiveUrls.map(item => ({
+        source: item.sourceUrl,
+        strategy: item.strategy,
+        paginationPages: item.paginationPages,
+        urlCount: item.urls.length,
+        urls: item.urls,
+      })),
+    };
+    
+    // Ensure directory exists
+    const dir = join(outputPath, '..');
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    
+    writeFileSync(outputPath, JSON.stringify(linksData, null, 2));
+  }
+  
   /**
    * Adds a URL to the crawl queue for an archive.
    * Prevents duplicates and already visited URLs.


### PR DESCRIPTION
## Summary
- Removes global collected-links.json file
- Saves collected-links.json in each archive's output directory
- Improves organization and prevents conflicts

## Problem
The collected-links.json file was being saved in the current working directory, which could lead to:
- Confusion about which archive the links belong to
- Overwriting when running different archives
- Cluttering the project root

## Solution
1. Added `saveArchiveCollectedLinks` method to StateService to save links per archive
2. Modified web crawler to save collected links in each archive's output directory
3. Removed the global `--save-links` CLI option (now automatic)
4. Updated the report generation to work from in-memory data

## Benefits
- Collected links are now organized with their respective archives
- Each archive has its own collected-links.json in its output directory
- No more conflicts or confusion about which links belong to which archive
- Cleaner project structure

## Test plan
- [x] Run `archivist crawl --dry-run` and verify collected-links.json is created in each archive directory
- [x] Verify the files contain the correct archive-specific URLs
- [x] Ensure no collected-links.json is created in the project root
- [x] Test with multiple archives to ensure each gets its own file